### PR TITLE
gold rush rule addition: referee tanks cannot shoot

### DIFF
--- a/html/Gamemodes.html
+++ b/html/Gamemodes.html
@@ -448,6 +448,9 @@
                             A round begins when Referee tanks reach far corners of the maze, and the Referee types "Go" in the chat.
                         </li>
                         <li>
+                            Referee tanks must NOT shoot any bullets.
+                        </li>
+                        <li>
                             The player with the highest score after 15 rounds is the winner.
                         </li>
                         <li>


### PR DESCRIPTION
referees' bullets will mess up the scoring system unless safely caught by one of the referee tanks